### PR TITLE
Hotfix(footer): Remove width to not have the scrollbar

### DIFF
--- a/src/static/css/Footer.css
+++ b/src/static/css/Footer.css
@@ -1,5 +1,4 @@
 footer {
-    width: 100vw;
     height: 200px;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

Before this PR, we have a `scrollbar` to go on the side because of the `width` of the footer (100vw). So I remove the `width`.